### PR TITLE
fix: create Open VSX namespace before publishing

### DIFF
--- a/.github/workflows/publish-ovsx.yml
+++ b/.github/workflows/publish-ovsx.yml
@@ -20,5 +20,8 @@ jobs:
       - name: Package extension
         run: npx @vscode/vsce package
 
+      - name: Create namespace if needed
+        run: npx ovsx create-namespace stuart -p ${{ secrets.OVSX_TOKEN }} || true
+
       - name: Publish to Open VSX
         run: npx ovsx publish *.vsix -p ${{ secrets.OVSX_TOKEN }}


### PR DESCRIPTION
Add ovsx create-namespace step to workflow so the publisher namespace exists before the first publish.